### PR TITLE
Fix FSNotify Firing Twice And Added Killing Of Previous Processes Before Starting A New One Or Exiting.

### DIFF
--- a/rld.go
+++ b/rld.go
@@ -4,10 +4,13 @@ package main
 
 import (
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -18,33 +21,53 @@ var (
 	version = "0.0.1"
 	process *os.Process
 )
+
 var usage = `Usage: rld <file>
 Options:
   <file> - The filepath to watch for changes
 `
 
 func main() {
+	// if len(os.Args) < 2 {
+	// 	errUsage()
+	// }
+
+	var (
+		check fs.FileInfo
+		err   error
+		path  string
+		args  []string
+	)
 	if len(os.Args) < 2 {
-		errUsage()
+		path = "."
+	} else {
+		path = os.Args[1]
 	}
 
-	f := os.Args[1]
+	if len(os.Args) > 2 {
+		args = os.Args[2:]
+	}
+
+	check, err = os.Stat(path)
+	if err != nil {
+		log.Fatal("1", err)
+	}
 
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("2", err)
 	}
 	defer watcher.Close()
 
 	waiting := false
 	timer := time.NewTimer(1000 * time.Millisecond)
 	sigs := make(chan os.Signal, 1)
-	echan := make(chan bool)
+	echan := make(chan struct{})
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	filesToSkip := []string{"vendor"}
 
 	// run command and watch file for changes
-	info(f)
-	go runCmd(f)
+	//info(check.Name())
 
 	go func() {
 		for {
@@ -69,21 +92,75 @@ func main() {
 				if waiting {
 					fmt.Println("[rld] no further change detected, restarting...")
 					killPid(process)
-					go runCmd(f)
+					go runCmd(path)
 					waiting = false
 				}
+
 			case err := <-watcher.Errors:
-				log.Fatal(err)
+				log.Fatal("3", err)
+
 			case sig := <-sigs:
 				fmt.Println()
 				fmt.Println(sig)
-				echan <- true
+				close(echan)
 			}
 		}
 	}()
 
-	if err := watcher.Add(f); err != nil {
-		log.Fatal(err)
+	go func() {
+		var input string
+		for {
+			fmt.Scanln(&input)
+			if input == "rst" {
+				fmt.Println("[rld] manual input requested, restarting...")
+				killPid(process)
+				go runCmd(path)
+			}
+		}
+	}()
+
+	if check.IsDir() {
+		fmt.Println("[rld] Directory detected")
+		fmt.Println(path)
+
+		if path != "." {
+			err := os.Chdir(path)
+			if err != nil {
+				log.Fatal("4", err)
+			}
+			path = "."
+		}
+
+		if _, err := os.Stat(path + "/go.mod"); err != nil {
+			log.Fatal("No go.mod File Found In Directory, Exiting")
+		}
+		filepath.Walk(path, func(docpath string, fileinfo os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if fileinfo.IsDir() {
+				if contains(filesToSkip, fileinfo.Name()) || fileinfo.Name() != "." && strings.HasPrefix(fileinfo.Name(), ".") {
+					fmt.Printf("Skipping Dir %v\n", fileinfo.Name())
+					return filepath.SkipDir
+				}
+
+			} else {
+				if filepath.Ext(fileinfo.Name()) == ".go" && !strings.Contains(fileinfo.Name(), "_test") {
+					info(docpath)
+					err = watcher.Add(path)
+				}
+			}
+
+			return err
+		})
+		go runCmd(path)
+	} else {
+		fmt.Println("[rld] File detected")
+		info(path)
+		if err := watcher.Add(check.Name()); err != nil {
+			log.Fatal("5", err)
+		}
+		go runCmd(fmt.Sprintf("%s %s", path, strings.Join(args, " ")))
 	}
 
 	//	go func() { <-done }()
@@ -94,13 +171,14 @@ func main() {
 }
 
 func info(f string) {
-	fmt.Println("[rld] version=", version)
 	fmt.Println("[rld] watching changes for", f)
 }
 
 func runCmd(file string) {
 	fmt.Println("[rld] exec: go run", file)
-	cmd := exec.Command("go", "run", file)
+	args := []string{"run"}
+	args = append(args, strings.Fields(file)...)
+	cmd := exec.Command("go", args...)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
@@ -122,4 +200,17 @@ func killPid(process *os.Process) {
 	if process != nil {
 		syscall.Kill(-process.Pid, syscall.SIGKILL)
 	}
+}
+
+func contains(arr []string, elem string) bool {
+	if strings.HasPrefix(elem, ".") {
+		return false
+	}
+
+	for _, i := range arr {
+		if elem == i {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
##### What Does This Pull Request Do?
Fixes A Strange Instance Where FSNotify Send Two Events Even If File Was Modified Once [See This Issue](https://github.com/fsnotify/fsnotify/issues/344), 
Also Fixes #4 Which Ensures That A Previous Process Has Been Killed Before Starting Another One Or Exiting. 

##### Where Should The Reviewer Start?
rld.go Has Multiple Changes Which:
- Removes An Unused Done Channel (Which I Presume Was Supposed To Block).
- Adds A Global Process Variable For Monitoring New Spawned Process.
- Add A Timer Variable For Monitoring Multiple Writes To A File
- killPid Function For Killing The Current Process Before Starting A New One

##### How Should This Be Manually Tested?
Run The Reloader And Monitor A File Then Proceed To Make Changes To It Using A Text Editor. On File Close, The Previous Process Will Be Killed And A New One Started.
